### PR TITLE
adds left shift and signed right shift

### DIFF
--- a/assembly/__tests__/bitwise_operations.spec.ts
+++ b/assembly/__tests__/bitwise_operations.spec.ts
@@ -84,3 +84,40 @@ describe("Bitwise operations", () => {
     }
   });
 });
+
+describe("Bit shift operations", () => {
+  it("signedRightShift 0", () => {
+    const a: BigInt = BigInt.fromString("-0xFFFFFFFFFFFFFFFF", 16);
+    const b: i32 = 32;
+    const expected: string = BigInt.fromString("-0x100000000").toString(16);
+    expect(a.signedRightShift(b).toString(16)).toStrictEqual(expected);
+  });
+
+  it("signedRightShift 1", () => {
+    const a: BigInt = BigInt.fromString(
+      "-25507431480953844704972967720876361174235818"
+    );
+    const b: i32 = 128;
+    expect(a.signedRightShift(b).toString()).toStrictEqual("-74960");
+
+    const c: BigInt = BigInt.fromString(
+      "-25507136738496115906217642097115107115900113"
+    );
+    const d: i32 = 128;
+    expect(c.signedRightShift(d).toString()).toStrictEqual("-74959");
+  });
+
+  it("signedRightShift 2", () => {
+    const a: BigInt = BigInt.fromString(
+      "-93994560579844054221777395143231145110420138"
+    );
+    const b: i32 = 128;
+    expect(a.signedRightShift(b).toString()).toStrictEqual("-276226");
+
+    const c: BigInt = BigInt.fromString(
+      "-93994265837386325423022069519469891052084433"
+    );
+    const d: i32 = 128;
+    expect(c.signedRightShift(d).toString()).toStrictEqual("-276225");
+  });
+});


### PR DESCRIPTION
New: 
- left shift and signed right shift methods
- fromString now recognizes that numbers prefixed with `0x` are hex strings even if radix argument defaults to 10
- added static method BigInt.NEG_ONE, which returns a BigInt of value -1