### PR TITLE
version 0.3.3 -> 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ const quotient: BigInt = a.div(b);
 const remainder: BigInt = a.mod(b);
 const squareRoot: BigInt = a.sqrt();
 const cubed: BigInt = a.pow(3);
+const roundedQuotient: BigInt = a.roundedDiv(b);
 
 // faster operations when right-side variable is a 32 bit unsigned integer:
 const c: u32 = 1234;
@@ -43,6 +44,7 @@ const intDifference: BigInt = a.subInt(c);
 const intProduct: BigInt = a.mulInt(c); // mulInt only supports 28 bit intger arguments (max value: 268435456)
 const intQuotient: BigInt = a.divInt(c);
 const intRemainder: BigInt = a.modInt(c);
+const intRoundedQuotient: BigInt = a.roundedDivInt(c);
 
 // arithmetic bit shifts (operator overloads: <<, >>)
 const shiftLeft: BigInt = a.mul2();

--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ or
 import { BigInt } from "as-bigint"
 
 // read BigInt from string
-const a: BigInt = BigInt.fromString("193745297349878926345309275287390603279729047130943891478958917983475091793475173497590134709571089374907109387571937458034975817093477309837980579034797");
+const a: BigInt = BigInt.fromString("19374529734987892634530927528739060327972904713094389147895891798347509179347517");
 
 // fromString and toString methods optionally take a radix argument
 const b: BigInt = BigInt.fromString("9F59E5Ed123C10D57E92629612511b14628D2799", 16);
+
+// for hex strings, a radix argument is not required if value is prefixed by 0x (or -0x for negative numbers)
+const fromHex: BigInt = BigInt.fromString("0x9F59E5Ed123C10D57E92629612511b14628D2799");
 
 // arithmetic (operator overloads: +, -, *, /, %, **)
 const sum: BigInt = a.add(b);
@@ -46,11 +49,21 @@ const intQuotient: BigInt = a.divInt(c);
 const intRemainder: BigInt = a.modInt(c);
 const intRoundedQuotient: BigInt = a.roundedDivInt(c);
 
-// arithmetic bit shifts (operator overloads: <<, >>)
-const shiftLeft: BigInt = a.mul2();
-const shiftLeft3bits: BigInt = a.mulPowTwo(3);
-const shiftRight: BigInt = a.div2();
-const shiftRight4bits: BigInt = a.divPowTwo(4);
+// fast multiply and divide by 2 or power of 2
+const mulByTwo: BigInt = a.mul2();
+const mulByEight: BigInt = a.mulPowTwo(3);
+const divBuTwo: BigInt = a.div2();
+const divBySixteen: BigInt = a.divPowTwo(4);
+
+// signed arithmetic bit shifts (operator overloads: <<, >>)
+const shiftLeft3bits: BigInt = a.leftShift(3);
+const shiftRight4bits: BigInt = a.rightShift(4);
+
+// bitwise operations (operator overloads: ~, &, |, ^)
+const not: BigInt = BigInt.bitwiseNot(bigIntA);
+const and: BigInt = BigInt.bitwiseAnd(bigIntA, bigIntB);
+const or: BigInt = BigInt.bitwiseOr(bigIntA, bigIntB);
+const xor: BigInt = BigInt.bitwiseXor(bigIntA, bigIntB);
 
 // comparison operations (operator overloads: ==, !=, <, <=, >, >=)
 const isEqual: boolean = a.eq(b);
@@ -85,12 +98,6 @@ const myInt32: i32 = BigInt.toInt32();
 const myInt64: i64 = BigInt.toInt64();
 const myUInt32: u32 = BigInt.toUInt32();
 const myUInt64: u64 = BigInt.toUInt64();
-
-// bitwise operations (operator overloads: ~, &, |, ^)
-const not: BigInt = BigInt.bitwiseNot(bigIntA);
-const and: BigInt = BigInt.bitwiseAnd(bigIntA, bigIntB);
-const or: BigInt = BigInt.bitwiseOr(bigIntA, bigIntB);
-const xor: BigInt = BigInt.bitwiseXor(bigIntA, bigIntB);
 ```
 
 ## Development Status & Roadmap
@@ -110,7 +117,7 @@ Modular reduction | N/A | Not implemented
 Random number generation | N/A | Not implemented
 Cryptographic functions | N/A | Not implemented
 
-Note that operator overloads `<<`, `>>`, and `**` only support right-hand operands that are positive integers and that fit in an i32--i.e. between the range (0, 2147483647].
+Note that operator overloads `<<`, `>>`, and `**` only support right-hand operands that fit in an i32--i.e. between the range (0, 2147483647].
 
 ### TODO List
 *Priority based on blockchain-related use case; 1 is highest priority, 5 is lowest*

--- a/assembly/BigInt.ts
+++ b/assembly/BigInt.ts
@@ -14,10 +14,12 @@ export class BigInt {
   // private static readonly doubleActualBits: i32 = 64 // 2 * BigIntMP.actualBits -> "double precision" actual bits
   private static readonly maxComba: i32 = 256; // 2^(doubleActualBits - 2 * p) = 2^8 = 256
 
-  private static readonly digitMask: u32 =
-    ((<u32>1) << (<u32>BigInt.p)) - <u32>1; // mask p least significant bits
+  private static readonly digitMask: u32 = <u32>((1 << BigInt.p) - 1); // mask p least significant bits
 
   private static readonly precision: i32 = 5; // base array size fits 140 bit integers
+
+  // private static readonly maxBits: i32 = I32.MAX_VALUE;
+  // private static readonly maxN: i32 = BigInt.maxBits / BigInt.p;
 
   // CONSTRUCTORS //////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -33,14 +35,19 @@ export class BigInt {
     if (radix < 2 || radix > 16) {
       throw new RangeError("BigInt only reads strings of radix 2 through 16");
     }
-    if (radix == 16 && bigInteger.startsWith("0x")) {
-      bigInteger = bigInteger.substring(2);
-    }
     let i: i32 = 0;
     let isNegative: boolean = false;
     if (bigInteger.charAt(0) == "-") {
       i++;
       isNegative = true;
+    }
+    if (
+      (radix == 16 || radix == 10) &&
+      bigInteger.charAt(i) == "0" &&
+      bigInteger.charAt(i + 1) == "x"
+    ) {
+      i += 2;
+      radix = 16;
     }
     let res: BigInt = BigInt.fromUInt16(0);
     const radixU: u16 = <u16>radix;
@@ -549,7 +556,7 @@ export class BigInt {
     // shift by k % p bits
     const remK: i32 = k % BigInt.p;
     if (remK != 0) {
-      const mask: u32 = ((<u32>1) << remK) - <u32>1;
+      const mask: u32 = <u32>((1 << remK) - 1);
       const shift: i32 = BigInt.p - remK;
       let r: u32 = 0;
       for (let i = 0; i < res.n; i++) {
@@ -567,7 +574,7 @@ export class BigInt {
   // divide by power of 2
   divPowTwo(k: i32): BigInt {
     const res = this.copy();
-    if (k == 0) {
+    if (k <= 0) {
       return res;
     }
     if (k >= BigInt.p) {
@@ -575,7 +582,7 @@ export class BigInt {
     }
     const remK: i32 = k % BigInt.p;
     if (remK != 0) {
-      const mask: u32 = ((<u32>1) << remK) - <u32>1;
+      const mask: u32 = <u32>((1 << remK) - 1);
       const shift: i32 = BigInt.p - remK;
       let r: u32 = 0;
       for (let i = res.n - 1; i >= 0; i--) {
@@ -611,6 +618,193 @@ export class BigInt {
     res.trimLeadingZeros();
     return res;
   }
+
+  // left bit shift
+  leftShift(k: i32): BigInt {
+    if (k == 0) return this.copy();
+    if (k < 0) return this.rightShiftByAbsolute(k);
+    return this.leftShiftByAbsolute(k);
+  }
+
+  // signed right bit shift
+  rightShift(k: i32): BigInt {
+    if (k == 0) return this.copy();
+    if (k < 0) return this.leftShiftByAbsolute(k);
+    return this.rightShiftByAbsolute(k);
+  }
+
+  private leftShiftByAbsolute(k: i32): BigInt {
+    return this.mulPowTwo(k >>> 0);
+  }
+
+  private rightShiftByAbsolute(k: i32): BigInt {
+    const shift: i32 = k >>> 0;
+    // shift by max if result would equal 0
+    if (this.n - shift / BigInt.p <= 0) {
+      return BigInt.rightShiftByMaximum(this.isNeg);
+    }
+    // arithmetic shift
+    const res: BigInt = this.divPowTwo(shift);
+    // for negative numbers, round down if a bit would be shifted out
+    // Since the result is negative, rounding down means adding one to its absolute value. This cannot overflow.
+    if (this.rightShiftMustRoundDown(shift)) {
+      return res._addOne(true);
+    }
+    return res;
+  }
+
+  // For negative numbers, round down if any bit was shifted out (so that
+  // e.g. -5n >> 1n == -3n and not -2n). Check now whether this will happen
+  // and whether it can cause overflow into a new digit. If we allocate the
+  // result large enough up front, it avoids having to do grow it later.
+  private rightShiftMustRoundDown(k: i32): boolean {
+    if (this.isNeg) {
+      const digitShift: i32 = k / BigInt.p;
+      const remK: i32 = k % BigInt.p;
+      const mask: u32 = <u32>((1 << remK) - 1);
+      if ((this.d[digitShift] & mask) != 0) {
+        return true;
+      } else {
+        for (let i = 0; i < digitShift; i++) {
+          if (this.d[i] != 0) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private static rightShiftByMaximum(isNeg: boolean): BigInt {
+    if (isNeg) {
+      return BigInt.NEG_ONE;
+    }
+    return BigInt.ZERO;
+  }
+
+  // based on Google's JSBI: https://github.com/GoogleChromeLabs/jsbi/blob/main/lib/jsbi.ts#L303
+  // private leftShiftByAbsolute(k: i32): BigInt {
+  //   const shift: i32 = BigInt.toShiftAmount(k);
+  //   if (shift < 0) {
+  //     throw new RangeError("BigInt would exceed maximize size");
+  //   }
+  //   const digitShift: i32 = (shift / BigInt.p) | 0;
+  //   const remK: i32 = shift % BigInt.p;
+  //   const grow: boolean =
+  //     remK != 0 && this.d[this.n - 1] >>> (BigInt.p - remK) != 0;
+  //   const resultLength = this.n + digitShift + (grow ? 1 : 0);
+  //   const res: BigInt = BigInt.getEmptyResultContainer(
+  //     resultLength,
+  //     this.isNeg,
+  //     resultLength
+  //   );
+  //
+  //   // shift by entire digits
+  //   for (let i = 0; i < digitShift; i++) {
+  //     res.d[i] = 0;
+  //   }
+  //   if (remK === 0) {
+  //     for (let i = digitShift; i < resultLength; i++) {
+  //       res.d[i] = this.d[i - digitShift];
+  //     }
+  //   } else {
+  //     // shift by k % p bits
+  //     const shift: i32 = BigInt.p - remK;
+  //     let carry = 0;
+  //     for (let i = 0; i < this.n; i++) {
+  //       const d: u32 = this.d[i];
+  //       res.d[i + digitShift] = ((d << remK) & BigInt.digitMask) | carry;
+  //       carry = d >>> shift;
+  //     }
+  //     if (grow) {
+  //       res.d[this.n + digitShift] = carry;
+  //     } else if (carry !== 0) {
+  //       throw new Error("implementation bug");
+  //     }
+  //   }
+  //
+  //   res.trimLeadingZeros();
+  //   return res;
+  // }
+
+  // based on Google's JSBI: https://github.com/GoogleChromeLabs/jsbi/blob/main/lib/jsbi.ts#L303
+  // private rightShiftByAbsolute(k: i32): BigInt {
+  //   const shift: i32 = BigInt.toShiftAmount(k);
+  //   if (shift < 0) {
+  //     return BigInt.rightShiftByMaximum(this.isNeg);
+  //   }
+  //   const digitShift: i32 = shift / BigInt.p;
+  //   const remK: i32 = shift % BigInt.p;
+  //
+  //   let resultLength: i32 = this.n - digitShift;
+  //   if (resultLength <= 0) {
+  //     return BigInt.rightShiftByMaximum(this.isNeg);
+  //   }
+  //   // For negative numbers, round down if any bit was shifted out (so that
+  //   // e.g. -5n >> 1n == -3n and not -2n). Check now whether this will happen
+  //   // and whether it can cause overflow into a new digit. If we allocate the
+  //   // result large enough up front, it avoids having to do grow it later.
+  //   let mustRoundDown = false;
+  //   if (this.isNeg) {
+  //     const mask: u32 = <u32>((1 << remK) - 1);
+  //     if ((this.d[digitShift] & mask) !== 0) {
+  //       mustRoundDown = true;
+  //     } else {
+  //       for (let i = 0; i < digitShift; i++) {
+  //         if (this.d[i] !== 0) {
+  //           mustRoundDown = true;
+  //           break;
+  //         }
+  //       }
+  //     }
+  //   }
+  //   // If bitsShift is non-zero, it frees up bits, preventing overflow.
+  //   if (mustRoundDown && remK === 0) {
+  //     // Overflow cannot happen if the most significant digit has unset bits.
+  //     const msd: u32 = this.d[this.n - 1];
+  //     const roundingCanOverflow = ~msd === 0;
+  //     if (roundingCanOverflow) {
+  //       resultLength++;
+  //     }
+  //   }
+  //   let res: BigInt = BigInt.getEmptyResultContainer(
+  //     resultLength,
+  //     this.isNeg,
+  //     resultLength
+  //   );
+  //
+  //   if (remK === 0) {
+  //     // Zero out any overflow digit (see "roundingCanOverflow" above).
+  //     res.d[resultLength - 1] = 0;
+  //     for (let i = digitShift; i < this.n; i++) {
+  //       res.d[i - digitShift] = this.d[i];
+  //     }
+  //   } else {
+  //     let carry: u32 = this.d[digitShift] >>> remK;
+  //     const last: i32 = this.n - digitShift - 1;
+  //     for (let i = 0; i < last; i++) {
+  //       const d = this.d[i + digitShift + 1];
+  //       res.d[i] = ((d << (BigInt.p - remK)) & BigInt.digitMask) | carry;
+  //       carry = d >>> remK;
+  //     }
+  //     res.d[last] = carry;
+  //   }
+  //   if (mustRoundDown) {
+  //     // Since the result is negative, rounding down means adding one to its
+  //     // absolute value. This cannot overflow.
+  //     res = res._addOne(true);
+  //   }
+  //   res.trimLeadingZeros();
+  //   return res;
+  // }
+
+  // private static toShiftAmount(k: i32): i32 {
+  //   const value: i32 = k >>> 0;
+  //   if (value > BigInt.maxBits) {
+  //     return -1;
+  //   }
+  //   return value;
+  // }
 
   // MULTIPLICATION ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -710,6 +904,31 @@ export class BigInt {
     const res1 = this.div(res);
     return res.lt(res1) ? res : res1;
   }
+
+  // alternative sqrt method used in uniswap v3 sdk -> is this faster?
+  // https://github.com/Uniswap/sdk-core/blob/main/src/utils/sqrt.ts
+  // sqrt(value: BigInt): BigInt {
+  //   if (value < BigInt.ZERO) {
+  //     throw new Error("cannot calculate square root of negative number");
+  //   }
+  //
+  //   // rely on built in sqrt if possible
+  //   if (value <= BigInt.fromUInt64(<u64>F64.MAX_SAFE_INTEGER)) {
+  //     const fVal: f64 = <f64>value.toUInt64();
+  //     const fSqrt: f64 = Math.floor(Math.sqrt(fVal));
+  //     return BigInt.fromUInt64(<u64>fSqrt);
+  //   }
+  //
+  //   let z: BigInt;
+  //   let x: BigInt;
+  //   z = value;
+  //   x = value.div2().add(BigInt.ONE);
+  //   while (x < z) {
+  //     z = x;
+  //     x = value.div(x).add(x).div2();
+  //   }
+  //   return z;
+  // }
 
   // DIVISION //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1229,12 +1448,21 @@ export class BigInt {
 
   // SYNTAX SUGAR ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+  // BigInt with value 0
   static get ZERO(): BigInt {
     return BigInt.fromUInt16(0);
   }
 
+  // BigInt with value 1
   static get ONE(): BigInt {
     return BigInt.fromUInt16(1);
+  }
+
+  // BigInt with value -1
+  static get NEG_ONE(): BigInt {
+    const res: BigInt = BigInt.fromUInt16(1);
+    res.isNeg = true;
+    return res;
   }
 
   static eq(left: BigInt, right: BigInt): boolean {
@@ -1293,13 +1521,13 @@ export class BigInt {
 
   // note: the right-hand operand must be a positive integer that fits in an i32
   @operator("<<")
-  private static mulPowTwo(left: BigInt, right: BigInt): BigInt {
-    return left.mulPowTwo(right.toInt32());
+  private static leftShift(left: BigInt, right: BigInt): BigInt {
+    return left.leftShift(right.toInt32());
   }
 
   // note: the right-hand operand must be a positive integer that fits in an i32
   @operator(">>")
-  private static divPowTwo(left: BigInt, right: BigInt): BigInt {
-    return left.divPowTwo(right.toInt32());
+  private static rightShift(left: BigInt, right: BigInt): BigInt {
+    return left.rightShift(right.toInt32());
   }
 }

--- a/assembly/BigInt.ts
+++ b/assembly/BigInt.ts
@@ -885,25 +885,6 @@ export class BigInt {
     return this.add(r).div(other);
   }
 
-  // divides and rounds to nearest integer
-  // roundedDiv(other: BigInt): BigInt {
-  //   if (other.eq(BigInt.fromUInt16(0))) {
-  //     throw new Error("Divide by zero");
-  //   }
-  //   let n: BigInt = this;
-  //   let d: BigInt = other;
-  //   if (d.isNeg) {
-  //     n = n.opposite();
-  //     d = d.opposite();
-  //   }
-  //   const adj: BigInt = (n.isNeg ? d.subInt(1) : d).div2();
-  //   const res: BigInt = n.abs().add(adj).div(d);
-  //   if (this.isNeg) {
-  //     res.isNeg = !res.isNeg;
-  //   }
-  //   return res;
-  // }
-
   // SINGLE-DIGIT HELPERS //////////////////////////////////////////////////////////////////////////////////////////////
 
   addInt(b: u32): BigInt {
@@ -1038,8 +1019,11 @@ export class BigInt {
     if (this.isZero()) {
       return BigInt.fromUInt16(0);
     }
-    const r: u32 = (this.isNeg ? -1 : 1) * (b >> 1);
-    return this.add(BigInt.fromUInt32(r)).divInt(b);
+    const r: BigInt = BigInt.fromUInt32(b >> 1);
+    if (this.isNeg) {
+      r.isNeg = true;
+    }
+    return this.add(r).divInt(b);
   }
 
   // BITWISE OPERATIONS ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/assembly/BigInt.ts
+++ b/assembly/BigInt.ts
@@ -33,6 +33,9 @@ export class BigInt {
     if (radix < 2 || radix > 16) {
       throw new RangeError("BigInt only reads strings of radix 2 through 16");
     }
+    if (radix == 16 && bigInteger.startsWith("0x")) {
+      bigInteger = bigInteger.substring(2);
+    }
     let i: i32 = 0;
     let isNegative: boolean = false;
     if (bigInteger.charAt(0) == "-") {

--- a/assembly/__tests__/arithmetic_operations.spec.ts
+++ b/assembly/__tests__/arithmetic_operations.spec.ts
@@ -310,6 +310,28 @@ describe("BigInt: Arithmetic", () => {
       "23975"
     );
 
+    // negative numerator; ends in 0.6 -> rounds up
+    const intN = "-34534353535397";
+    const intO: u32 = U32.MAX_VALUE;
+    const biN = BigInt.fromString(intN);
+    const biO = BigInt.fromUInt32(intO);
+    expect(biN.roundedDiv(biO).toString()).toStrictEqual("-8041");
+    expect(biN.roundedDivInt(intO).toString()).toStrictEqual("-8041");
+
+    // negative denominator; ends in 0.52 -> rounds up
+    const intR = "34534353535397972";
+    const intS: string = I32.MIN_VALUE.toString();
+    const biR = BigInt.fromString(intR);
+    const biS = BigInt.fromString(intS);
+    expect(biR.roundedDiv(biS).toString()).toStrictEqual("-16081312");
+
+    // negative numerator and denominator; ends in 0.52 -> rounds up
+    const intP = "-34534353535397972";
+    const intQ: string = I32.MIN_VALUE.toString();
+    const biP = BigInt.fromString(intP);
+    const biQ = BigInt.fromString(intQ);
+    expect(biP.roundedDiv(biQ).toString()).toStrictEqual("16081312");
+
     // divide by zero
     const divByZero = (): void => {
       const nonZero = BigInt.fromString(

--- a/assembly/__tests__/arithmetic_operations.spec.ts
+++ b/assembly/__tests__/arithmetic_operations.spec.ts
@@ -348,6 +348,14 @@ describe("BigInt: Arithmetic", () => {
     expect(biV.roundedDiv(biW).toString()).toStrictEqual("0");
     expect(biV.roundedDivInt(intW).toString()).toStrictEqual("0");
 
+    // negative numerator; ends in 0.5 -> rounds up
+    const intX = "-5";
+    const intY: u32 = 10;
+    const biX = BigInt.fromString(intX);
+    const biY = BigInt.fromUInt32(intY);
+    expect(biX.roundedDiv(biY).toString()).toStrictEqual("-1");
+    expect(biX.roundedDivInt(intY).toString()).toStrictEqual("-1");
+
     // divide by zero
     const divByZero = (): void => {
       const nonZero = BigInt.fromString(

--- a/assembly/__tests__/arithmetic_operations.spec.ts
+++ b/assembly/__tests__/arithmetic_operations.spec.ts
@@ -318,6 +318,13 @@ describe("BigInt: Arithmetic", () => {
     expect(biN.roundedDiv(biO).toString()).toStrictEqual("-8041");
     expect(biN.roundedDivInt(intO).toString()).toStrictEqual("-8041");
 
+    // negative numerator and denominator; ends in 0.52 -> rounds up
+    const intP = "-34534353535397972";
+    const intQ: string = I32.MIN_VALUE.toString();
+    const biP = BigInt.fromString(intP);
+    const biQ = BigInt.fromString(intQ);
+    expect(biP.roundedDiv(biQ).toString()).toStrictEqual("16081312");
+
     // negative denominator; ends in 0.52 -> rounds up
     const intR = "34534353535397972";
     const intS: string = I32.MIN_VALUE.toString();
@@ -325,12 +332,21 @@ describe("BigInt: Arithmetic", () => {
     const biS = BigInt.fromString(intS);
     expect(biR.roundedDiv(biS).toString()).toStrictEqual("-16081312");
 
-    // negative numerator and denominator; ends in 0.52 -> rounds up
-    const intP = "-34534353535397972";
-    const intQ: string = I32.MIN_VALUE.toString();
-    const biP = BigInt.fromString(intP);
-    const biQ = BigInt.fromString(intQ);
-    expect(biP.roundedDiv(biQ).toString()).toStrictEqual("16081312");
+    // negative numerator; ends in 0.6 -> rounds up
+    const intT = "-6";
+    const intU: u32 = 10;
+    const biT = BigInt.fromString(intT);
+    const biU = BigInt.fromUInt32(intU);
+    expect(biT.roundedDiv(biU).toString()).toStrictEqual("-1");
+    expect(biT.roundedDivInt(intU).toString()).toStrictEqual("-1");
+
+    // negative numerator; ends in 0.4 -> rounds down
+    const intV = "-4";
+    const intW: u32 = 10;
+    const biV = BigInt.fromString(intV);
+    const biW = BigInt.fromUInt32(intW);
+    expect(biV.roundedDiv(biW).toString()).toStrictEqual("0");
+    expect(biV.roundedDivInt(intW).toString()).toStrictEqual("0");
 
     // divide by zero
     const divByZero = (): void => {

--- a/assembly/__tests__/bitwise_operations.spec.ts
+++ b/assembly/__tests__/bitwise_operations.spec.ts
@@ -84,3 +84,103 @@ describe("Bitwise operations", () => {
     }
   });
 });
+
+describe("Bit shift operations", () => {
+  it("right shift handles shifts past zero", () => {
+    const a: BigInt = BigInt.fromString(I16.MAX_VALUE.toString());
+    const b: i32 = 29;
+    expect(a.rightShift(b).toString()).toStrictEqual(BigInt.ZERO.toString());
+
+    const c: BigInt = BigInt.fromString(I16.MIN_VALUE.toString());
+    const d: i32 = 29;
+    expect(c.rightShift(d).toString()).toStrictEqual(BigInt.NEG_ONE.toString());
+  });
+
+  it("right shift 0", () => {
+    const a: BigInt = BigInt.fromString("-0xFFFFFFFFFFFFFFFF", 16);
+    const b: i32 = 32;
+    const expected: string = BigInt.fromString("-0x100000000").toString(16);
+    expect(a.rightShift(b).toString(16)).toStrictEqual(expected);
+  });
+
+  it("right shift 1", () => {
+    const a: BigInt = BigInt.fromString(
+      "-25507431480953844704972967720876361174235818"
+    );
+    const b: i32 = 128;
+    expect(a.rightShift(b).toString()).toStrictEqual("-74960");
+
+    const c: BigInt = BigInt.fromString(
+      "-25507136738496115906217642097115107115900113"
+    );
+    const d: i32 = 128;
+    expect(c.rightShift(d).toString()).toStrictEqual("-74959");
+  });
+
+  it("right shift 2", () => {
+    const a: BigInt = BigInt.fromString(
+      "-93994560579844054221777395143231145110420138"
+    );
+    const b: i32 = 128;
+    expect(a.rightShift(b).toString()).toStrictEqual("-276226");
+
+    const c: BigInt = BigInt.fromString(
+      "-93994265837386325423022069519469891052084433"
+    );
+    const d: i32 = 128;
+    expect(c.rightShift(d).toString()).toStrictEqual("-276225");
+  });
+
+  it("right shift 3", () => {
+    const a: BigInt = BigInt.fromString(
+      "93994560579844054221777395143231145110420138"
+    );
+    const b: i32 = 128;
+    expect(a.rightShift(b).toString()).toStrictEqual(a.divPowTwo(b).toString());
+
+    const c: BigInt = BigInt.fromString(
+      "93994265837386325423022069519469891052084433"
+    );
+    const d: i32 = 128;
+    expect(c.rightShift(d).toString()).toStrictEqual(c.divPowTwo(d).toString());
+  });
+
+  it("left shift 0", () => {
+    const a: BigInt = BigInt.fromString("0xFFFFFFFFFFFFFFFF");
+    const b: i32 = 32;
+    const expected: BigInt = BigInt.fromString("0xFFFFFFFFFFFFFFFF00000000");
+    expect(a.leftShift(b).toString(16)).toStrictEqual(expected.toString(16));
+  });
+
+  it("left shift 1", () => {
+    const a: BigInt = BigInt.fromString("-255074314809538447");
+    const b: i32 = 128;
+    expect(a.leftShift(b).toString()).toStrictEqual(
+      "-86797291584126329662795037610384099423694437550057848832"
+    );
+
+    const c: BigInt = BigInt.fromString("-255071367384961159062176420971");
+    const d: i32 = 128;
+    expect(c.leftShift(d).toString()).toStrictEqual(
+      "-86796288627514849176787787507933874830015166685408322978384000843776"
+    );
+  });
+
+  it("left shift 2", () => {
+    const a: BigInt = BigInt.fromString(
+      "93994560579844054221777395143231145110420138"
+    );
+    const b: i32 = 128;
+    expect(a.leftShift(b).toString()).toStrictEqual(
+      "31984691551802872875935365428754732408868752335117947616032289519756668612984700928"
+    );
+
+    const c: BigInt = BigInt.fromString(
+      "93994265837386325423022069519469891052084433"
+    );
+    const d: i32 = 128;
+    expect(c.leftShift(d).toString()).toStrictEqual(
+      "31984591256141724825642427191833617609100326214813829850676127900994504777109864448"
+    );
+  });
+});

--- a/assembly/__tests__/construction.spec.ts
+++ b/assembly/__tests__/construction.spec.ts
@@ -1,7 +1,5 @@
 import { BigInt } from "../BigInt";
 
-// TODO: test radix N input and output
-
 describe("String Construction", () => {
   it("Constructs from radix 10 strings", () => {
     // constructor with small integer
@@ -25,6 +23,21 @@ describe("String Construction", () => {
     const bigIntBigStrNeg = BigInt.fromString(bigStrNeg);
     expect(bigIntBigStrNeg.toString()).toStrictEqual(bigStrNeg);
     expect(bigIntBigStrNeg.isNegative).toStrictEqual(true);
+  });
+
+  it("Constructs from radix 16 strings", () => {
+    const hexStr: string = "6AA50BC48CA";
+    const biHex: BigInt = BigInt.fromString(hexStr, 16);
+    const expected: string = U64.parseInt(hexStr, 16).toString();
+    expect(biHex.toString()).toStrictEqual(expected);
+
+    const hexStr0x: string = "0x6AA50BC48CA";
+    const biHex0x: BigInt = BigInt.fromString(hexStr0x, 16);
+    const expected0x: string = U64.parseInt(
+      hexStr0x.substring(2),
+      16
+    ).toString();
+    expect(biHex0x.toString()).toStrictEqual(expected0x);
   });
 });
 

--- a/assembly/__tests__/operator_overloads.spec.ts
+++ b/assembly/__tests__/operator_overloads.spec.ts
@@ -82,14 +82,14 @@ describe("Operator overloads", () => {
     const biA = BigInt.fromString("238723509723496846245754754");
     const biB = BigInt.fromString("3");
     // @ts-ignore
-    expect(biA.mulPowTwo(3).toString()).toStrictEqual((biA << biB).toString());
+    expect(biA.leftShift(3).toString()).toStrictEqual((biA << biB).toString());
   });
 
   it(">>", () => {
     const biA = BigInt.fromString("238723509723496846245754754");
     const biB = BigInt.fromString("3");
     // @ts-ignore
-    expect(biA.divPowTwo(3).toString()).toStrictEqual((biA >> biB).toString());
+    expect(biA.rightShift(3).toString()).toStrictEqual((biA >> biB).toString());
   });
 
   it("**", () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/polywrap/as-bigint.git"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "types": "assembly/index.ts",
   "releaseFiles": [
     "assembly/",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/polywrap/as-bigint.git"
   },
-  "version": "0.3.3",
+  "version": "0.4.0",
   "types": "assembly/index.ts",
   "releaseFiles": [
     "assembly/",


### PR DESCRIPTION
New features:
- left shift and signed right shift methods that handle positive and negative values like native << and >> operators
- fromString now recognizes that numbers prefixed with 0x are hex strings even if radix argument defaults to 10
- fromString now drops "0x" prefix from hex strings
- added static method BigInt.NEG_ONE, which returns a BigInt of value -1
- bug fix for roundedDivInt(...)