### PR TITLE
Make divOp private

### DIFF
--- a/assembly/BigInt.ts
+++ b/assembly/BigInt.ts
@@ -1681,7 +1681,7 @@ export class BigInt {
   }
 
   @operator("/")
-  static divOp(left: BigInt, right: BigInt): BigInt {
+  private static divOp(left: BigInt, right: BigInt): BigInt {
     return left.div(right);
   }
 


### PR DESCRIPTION
Keeping the operators unified.